### PR TITLE
Slightly Improved Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,24 +19,44 @@ formats to flatpak bundles.
 
 ##Usage
 
-This will add the game to the `repo` directory:
+###Adding the game to your local repo
+
+You can define which repo to add the game to by using the `--repo` option:
 ```
-./game-to-flatpak [installer file]
+./game-to-flatpak --repo=[repo directory] [installer file]
 ```
 
-You will only need to do this once:
+If the specified directory is not already a repo, it will be created. If the 
+`--repo` option is not used, it will use the directory `repo`.
+
+If the repo you defined is new, you will need to add it to your Flatpak configuration
+before you can install it. This only needs to be run once:
 ```
-flatpak --user remote-add --no-gpg-verify --if-not-exists game-repo repo
+flatpak --user remote-add --no-gpg-verify --if-not-exists [repo name] [repo directory]
 ```
 
-Check which games are available in the repo:
+`game-to-flatpak` should print the game's name as it is running, but it can also
+be found with:
 ```
-flatpak --user remote-ls game-repo
+flatpak --user remote-ls [repo name]
 ```
 
-Install the game for that user:
+Finally, you can install the game from the repository:
 ```
-flatpak --user install game-repo com.gog.Call_of_Cthulhu__Shadow_of_the_Comet
+flatpak --user install [repo name] [game name]
+```
+
+###Building and installing a bundle
+
+You can also build a redistributable bundle with the `--bundle` option:
+```
+./game-to-flatpak --bundle [installer file]
+```
+
+These can be installed directly without a repo:
+
+```
+flatpak --user install [bundle filename]
 ```
 
 ##Similar projects

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-#game-to-flatpak
+# game-to-flatpak
 
 A script to automatically convert Linux game installers in various
 formats to flatpak bundles.
 
-##Requirements
+## Requirements
 
  - lua
  - lua-posix
@@ -12,14 +12,14 @@ formats to flatpak bundles.
  - unzip
  - flatpak
  
-##Features
+## Features
 
  - Supports the MojoSetup installer
  - Supports the MojoSetup + makeself installer (as used by GOG.com)
 
-##Usage
+## Usage
 
-###Adding the game to your local repo
+### Adding the game to your local repo
 
 You can define which repo to add the game to by using the `--repo` option:
 ```
@@ -46,7 +46,7 @@ Finally, you can install the game from the repository:
 flatpak --user install [repo name] [game name]
 ```
 
-###Building and installing a bundle
+### Building and installing a bundle
 
 You can also build a redistributable bundle with the `--bundle` option:
 ```
@@ -59,11 +59,11 @@ These can be installed directly without a repo:
 flatpak --user install [bundle filename]
 ```
 
-##Similar projects
+## Similar projects
 
- - [Unpacker classes] (https://cgit.gentoo.org/proj/gamerlay.git/tree/eclass) from [Gentoo's gamerlay] (https://cgit.gentoo.org/proj/gamerlay.git/)
- - [./play.it] (http://wiki.dotslashplay.it/en/start)'s [Debianification scripts] (http://www.dotslashplay.it/scripts/)
+ - [Unpacker classes](https://cgit.gentoo.org/proj/gamerlay.git/tree/eclass) from [Gentoo's gamerlay](https://cgit.gentoo.org/proj/gamerlay.git/)
+ - [./play.it](http://wiki.dotslashplay.it/en/start)'s [Debianification scripts](http://www.dotslashplay.it/scripts/)
 
-##Out of scope
+## Out of scope
 
  - WINE, DOSBox, etc. automagic wrappers are not planned, don't ask for them.

--- a/game-to-flatpak
+++ b/game-to-flatpak
@@ -23,7 +23,7 @@
 local fg = require "lib.flatpak-game"
 
 function usage()
-	print("game-to-flatpak [--network] [--keep-build-dir] [--bundle] [FILE...]")
+	print("game-to-flatpak [--network] [--keep-build-dir] [--bundle] [--keep-repo] [FILE...]")
 end
 
 local file = nil
@@ -34,6 +34,8 @@ for k, v in ipairs(arg) do
 			options.network = true
 		elseif v == '--keep-build-dir' then
 			options.keep_build_dir = true
+		elseif v == '--keep-repo' then
+			options.keep_repo_dir = true
 		elseif v == '--bundle' then
 			options.bundle = true
 		else

--- a/game-to-flatpak
+++ b/game-to-flatpak
@@ -23,7 +23,7 @@
 local fg = require "lib.flatpak-game"
 
 function usage()
-	print("build-game.lua [--network] [--keep-files] [--bundle] [FILE...]")
+	print("game-to-flatpak [--network] [--keep-files] [--bundle] [FILE...]")
 end
 
 local file = nil

--- a/game-to-flatpak
+++ b/game-to-flatpak
@@ -23,15 +23,18 @@
 local fg = require "lib.flatpak-game"
 
 function usage()
-	print("game-to-flatpak [--network] [--keep-build-dir] [--bundle] [--keep-repo] [FILE...]")
+	print("game-to-flatpak [--network] [--repo=DIR] [--keep-build-dir] [--bundle] [--keep-repo-dir] [FILE...]")
 end
 
 local file = nil
 local options = {}
+
 for k, v in ipairs(arg) do
 	if string.sub (v, 1, 2) == "--" then
 		if v == '--network' then
 			options.network = true
+		elseif string.sub(v, 1, 7) == '--repo=' then
+			options.repo_dir = string.gsub(v, '--repo=', '')
 		elseif v == '--keep-build-dir' then
 			options.keep_build_dir = true
 		elseif v == '--keep-repo' then
@@ -47,6 +50,15 @@ for k, v in ipairs(arg) do
 		file = v
 		break
 	end
+end
+
+if not options.repo_dir then
+	options.repo_dir = 'repo'
+elseif not options.keep_repo_dir then
+	-- Adding it to your local repo and also making a bundle should not delete
+	-- the whole local repo.
+	print('Repo directory defined, assuming --keep-repo.')
+	options.keep_repo_dir = true
 end
 
 if not file then

--- a/game-to-flatpak
+++ b/game-to-flatpak
@@ -23,7 +23,7 @@
 local fg = require "lib.flatpak-game"
 
 function usage()
-	print("game-to-flatpak [--network] [--keep-files] [--bundle] [FILE...]")
+	print("game-to-flatpak [--network] [--keep-build-dir] [--bundle] [FILE...]")
 end
 
 local file = nil
@@ -32,8 +32,8 @@ for k, v in ipairs(arg) do
 	if string.sub (v, 1, 2) == "--" then
 		if v == '--network' then
 			options.network = true
-		elseif v == '--keep-files' then
-			options.keep_files = true
+		elseif v == '--keep-build-dir' then
+			options.keep_build_dir = true
 		elseif v == '--bundle' then
 			options.bundle = true
 		else

--- a/lib/flatpak-game.lua
+++ b/lib/flatpak-game.lua
@@ -464,14 +464,16 @@ function handle(file, options)
 		return 1
 	end
 
-	if options.bundle and not build_bundle(metadata.id) then
-		print ("Could not build bundle for " .. file)
-		return 1
-	end
+    if options.bundle then
+        if not build_bundle(metadata.id) then
+            print ("Could not build bundle for " .. file)
+            return 1
+        elseif not options.keep_repo_dir then
+            remove_dir('repo')
+        end
+    end
 
 	if not options.keep_build_dir then
 		remove_dir(ROOT_DIR)
 	end
 end
-
-

--- a/lib/flatpak-game.lua
+++ b/lib/flatpak-game.lua
@@ -375,7 +375,7 @@ function save_manifest(metadata, enable_network)
 end
 
 function build_export()
-	local command = { 'flatpak', 'build-export', 'repo', ROOT_DIR }
+	local command = { 'flatpak', 'build-export', options.repo_dir, ROOT_DIR }
 	local f = io.popen(shell_quote(command), 'r')
 	if not f then
 		return false
@@ -386,7 +386,7 @@ function build_export()
 end
 
 function build_bundle(id)
-	local command = { 'flatpak', 'build-bundle', 'repo', id .. '.flatpak', id }
+	local command = { 'flatpak', 'build-bundle', options.repo_dir, id .. '.flatpak', id }
 	local f = io.popen(shell_quote(command), 'r')
 	if not f then
 		return false
@@ -459,7 +459,7 @@ function handle(file, options)
 
 	-- FIXME cleanup
 
-	if not build_export() then
+	if not build_export(options.repo_dir) then
 		print ("Could not export build for " .. file)
 		return 1
 	end
@@ -469,11 +469,11 @@ function handle(file, options)
 	end
 
 	if options.bundle then
-        if not build_bundle(metadata.id) then
+        if not build_bundle(metadata.id, options.repo_dir) then
             print ("Could not build bundle for " .. file)
             return 1
         elseif not options.keep_repo_dir then
-            remove_dir('repo')
+            remove_dir(options.repo_dir)
         end
     end
 

--- a/lib/flatpak-game.lua
+++ b/lib/flatpak-game.lua
@@ -469,7 +469,7 @@ function handle(file, options)
 		return 1
 	end
 
-	if not options.keep_files then
+	if not options.keep_build_dir then
 		remove_dir(ROOT_DIR)
 	end
 end

--- a/lib/flatpak-game.lua
+++ b/lib/flatpak-game.lua
@@ -464,7 +464,11 @@ function handle(file, options)
 		return 1
 	end
 
-    if options.bundle then
+	if not options.keep_build_dir then
+		remove_dir(ROOT_DIR)
+	end
+
+	if options.bundle then
         if not build_bundle(metadata.id) then
             print ("Could not build bundle for " .. file)
             return 1
@@ -473,7 +477,4 @@ function handle(file, options)
         end
     end
 
-	if not options.keep_build_dir then
-		remove_dir(ROOT_DIR)
-	end
 end


### PR DESCRIPTION
In general, these changes make game-to-flatpak a bit easier to use. I've introduced a few new options, clarified one, and added informational print statements before and after things that often take a while.

Specifically, I added the --repo option to export games to a directory more useful than just 'repo'. I made the --bundle option automatically delete the repo directory it exports to unless the --repo option is defined. Adding the --keep-repo option seemed necessary so that users could both export to a repo and get a bundle in one command. I changed the --keep-files option to --keep-build-dir to make it clear that it is not the repo files that will be deleted. 

I also added print statements before the verification, unpacking, and copying steps because they can take quite some time with large game files.

Furthermore, I moved the deletion of the build directory to just after the build-export function is called so that if the --bundle option is passed, it will only take up double the game's worth of disk space at once, not triple.

Lastly, I have updated the README to reflect these changes and fixed some of the apparent formatting mistakes.